### PR TITLE
Update node role taint

### DIFF
--- a/roles/k3s/templates/config.j2
+++ b/roles/k3s/templates/config.j2
@@ -22,7 +22,7 @@ tls-san: {{ k3s_vars.api.host }}
 node-taint:
   - node.cilium.io/agent-not-ready:NoExecute
 {% if k3s_vars.controlplane.tainted and k3s_service_type == 'server' %}
-  - node-role.kubernetes.io/master=true:NoSchedule
+  - node-role.kubernetes.io/control-plane:NoSchedule
 {% endif %}
 {% if k3s_ha_cluster and ansible_host != k3s_server_default_host and k3s_token | length > 0 %}
 {% if k3s_vars.loadbalancer.enabled and k3s_service_type == 'agent' %}

--- a/roles/longhorn/templates/values.j2
+++ b/roles/longhorn/templates/values.j2
@@ -3,18 +3,16 @@ defaultSettings:
   defaultReplicaCount: '{{ longhorn_vars.kubernetes.default_settings.replica_count }}'
   nodeDownPodDeletionPolicy: '{{ longhorn_vars.kubernetes.default_settings.pod_deletion_policy }}'
 {% if k3s_vars.controlplane.tainted %}
-  taintToleration: node-role.kubernetes.io/master=true:NoSchedule
+  taintToleration: node-role.kubernetes.io/control-plane:NoSchedule
 longhornDriver:
   tolerations:
-    - key: node-role.kubernetes.io/master
-      operator: Equal
-      value: 'true'
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
       effect: NoSchedule
 longhornManager:
   tolerations:
-    - key: node-role.kubernetes.io/master
-      operator: Equal
-      value: 'true'
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
       effect: NoSchedule
 {% endif %}
 persistence:


### PR DESCRIPTION
## WHY

Replace deprecated `master` [node role taint](https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-master-taint), with `control-plane`.

## WHAT

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not working as expected)
- [ ] This change requires a documentation update

## HOW

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
