### PR TITLE
Restructure helm plugins code

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -110,7 +110,7 @@
         "roles/helm/defaults/main.yaml"
       ],
       "matchStrings": [
-        "release:[\\s\\S]+plugin:[\\s\\S]+?version:\\s+(?<currentValue>.+)"
+        "plugins:[\\s\\S]+name:\\s+helm-diff[\\s\\S]+?version:\\s+(?<currentValue>.+)"
       ]
     },
     {

--- a/roles/argocd/tasks/facts.yaml
+++ b/roles/argocd/tasks/facts.yaml
@@ -11,12 +11,12 @@
 
 - name: Set project url fact
   ansible.builtin.set_fact:
-    argocd_project_url: https://github.com/{{ argocd_project_release }}/releases
+    argocd_project_url: https://github.com/{{ argocd_project_release }}/releases/tag
   run_once: true
 
 - name: Set project tag url fact
   ansible.builtin.set_fact:
-    argocd_project_url_tag: '{{ argocd_project_url }}/tag/{{ argocd_vars.kubernetes.helm.chart.name }}-{{ argocd_vars.kubernetes.helm.chart.version[1:] }}'
+    argocd_project_url_tag: '{{ argocd_project_url }}/{{ argocd_vars.kubernetes.helm.chart.name }}-{{ argocd_vars.kubernetes.helm.chart.version[1:] }}'
   run_once: true
 
 - name: Set release fact

--- a/roles/argocd/tasks/main.yaml
+++ b/roles/argocd/tasks/main.yaml
@@ -74,6 +74,7 @@
           kubernetes.core.helm:
             chart_ref: '{{ argocd_project_chart }}'
             chart_version: '{{ argocd_vars.kubernetes.helm.chart.version }}'
+            create_namespace: true
             kubeconfig: '{{ k3s_vars.directory.config }}/k3s.yaml'
             name: '{{ argocd_vars.kubernetes.helm.chart.name }}'
             namespace: '{{ argocd_vars.kubernetes.namespace }}'

--- a/roles/certmanager/tasks/facts.yaml
+++ b/roles/certmanager/tasks/facts.yaml
@@ -11,12 +11,12 @@
 
 - name: Set project url fact
   ansible.builtin.set_fact:
-    certmanager_project_url: https://github.com/{{ certmanager_project_release }}/releases
+    certmanager_project_url: https://github.com/{{ certmanager_project_release }}/releases/tag
   run_once: true
 
 - name: Set project tag url fact
   ansible.builtin.set_fact:
-    certmanager_project_url_tag: '{{ certmanager_project_url }}/tag/{{ certmanager_vars.kubernetes.helm.chart.version }}'
+    certmanager_project_url_tag: '{{ certmanager_project_url }}/{{ certmanager_vars.kubernetes.helm.chart.version }}'
   run_once: true
 
 - name: Set variables fact

--- a/roles/certmanager/tasks/main.yaml
+++ b/roles/certmanager/tasks/main.yaml
@@ -33,6 +33,7 @@
           kubernetes.core.helm:
             chart_ref: '{{ certmanager_project_chart }}'
             chart_version: '{{ certmanager_vars.kubernetes.helm.chart.version }}'
+            create_namespace: true
             kubeconfig: '{{ k3s_vars.directory.config }}/k3s.yaml'
             name: '{{ certmanager_vars.kubernetes.helm.chart.name }}'
             namespace: '{{ certmanager_vars.kubernetes.namespace }}'

--- a/roles/cilium/tasks/facts.yaml
+++ b/roles/cilium/tasks/facts.yaml
@@ -56,12 +56,12 @@
 
 - name: Set project url fact
   ansible.builtin.set_fact:
-    cilium_project_url: https://github.com/{{ cilium_project_chart }}/releases
+    cilium_project_url: https://github.com/{{ cilium_project_chart }}/releases/tag
   run_once: true
 
 - name: Set project tag url fact
   ansible.builtin.set_fact:
-    cilium_project_url_tag: '{{ cilium_project_url }}/tag/{{ cilium_vars.kubernetes.helm.chart.version }}'
+    cilium_project_url_tag: '{{ cilium_project_url }}/{{ cilium_vars.kubernetes.helm.chart.version }}'
   run_once: true
 
 - name: Set variables fact

--- a/roles/cilium/tasks/main.yaml
+++ b/roles/cilium/tasks/main.yaml
@@ -82,6 +82,7 @@
           kubernetes.core.helm:
             chart_ref: '{{ cilium_project_chart }}'
             chart_version: '{{ cilium_vars.kubernetes.helm.chart.version }}'
+            create_namespace: true
             kubeconfig: '{{ k3s_vars.directory.config }}/k3s.yaml'
             name: '{{ cilium_vars.kubernetes.helm.chart.name }}'
             namespace: '{{ cilium_vars.kubernetes.namespace }}'

--- a/roles/cloudflare/tasks/facts.yaml
+++ b/roles/cloudflare/tasks/facts.yaml
@@ -26,12 +26,12 @@
 
 - name: Set project url fact
   ansible.builtin.set_fact:
-    cloudflare_project_url: https://github.com/{{ cloudflare_project_chart }}/releases
+    cloudflare_project_url: https://github.com/{{ cloudflare_project_chart }}/releases/tag
   run_once: true
 
 - name: Set project tag url fact
   ansible.builtin.set_fact:
-    cloudflare_project_url_tag: '{{ cloudflare_project_url }}/tag/{{ cloudflare_project_tag }}'
+    cloudflare_project_url_tag: '{{ cloudflare_project_url }}/{{ cloudflare_project_tag }}'
   run_once: true
 
 - name: Set tls prefix fact

--- a/roles/cloudflare/tasks/main.yaml
+++ b/roles/cloudflare/tasks/main.yaml
@@ -41,6 +41,7 @@
           kubernetes.core.helm:
             chart_ref: '{{ cloudflare_project_chart }}'
             chart_version: '{{ cloudflare_vars.kubernetes.helm.chart.version }}'
+            create_namespace: true
             kubeconfig: '{{ k3s_vars.directory.config }}/k3s.yaml'
             name: '{{ cloudflare_vars.kubernetes.helm.chart.name }}'
             namespace: '{{ cloudflare_vars.kubernetes.namespace }}'

--- a/roles/helm/defaults/main.yaml
+++ b/roles/helm/defaults/main.yaml
@@ -1,17 +1,17 @@
 ---
 helm_vars:
-  release:
-    helm:
-      distro: debian
-      key: helm-archive-keyring.gpg
+  plugins:
+    - name: helm-diff
+      enabled: true
+      packages:
+        - python3-jsonpatch
       repository:
-        channel: stable
-        key: signing.asc
-        url: https://baltocdn.com/helm
-    plugin:
-      enabled: false
-      name: diff
-      repository:
-        name: helm-diff
-        org: databus23
+        url: https://github.com/databus23/helm-diff
       version: v3.9.6
+  release:
+    distro: debian
+    key: helm-archive-keyring.gpg
+    repository:
+      channel: stable
+      key: signing.asc
+      url: https://baltocdn.com/helm

--- a/roles/helm/tasks/facts.yaml
+++ b/roles/helm/tasks/facts.yaml
@@ -1,20 +1,28 @@
 ---
-- name: Set plugin release fact
+- name: Set plugin packages fact
   ansible.builtin.set_fact:
-    helm_plugin_release: '{{ helm_vars.release.plugin.repository.org }}/{{ helm_vars.release.plugin.repository.name }}'
+    helm_plugin_packages: '{{ item.packages }}'
+  loop: '{{ helm_vars.plugins }}'
   run_once: true
+  when:
+    - item.enabled
+    - item.packages is defined
 
-- name: Set plugin release url fact
+- name: Set plugin packages disabled fact
   ansible.builtin.set_fact:
-    helm_plugin_release_url: https://github.com/{{ helm_plugin_release }}
+    helm_plugin_packages_disabled: '{{ item.packages }}'
+  loop: '{{ helm_vars.plugins }}'
   run_once: true
+  when:
+    - not item.enabled
+    - item.packages is defined
 
 - name: Set release channel fact
   ansible.builtin.set_fact:
-    helm_release_channel: '{{ helm_vars.release.helm.repository.url }}/{{ helm_vars.release.helm.repository.channel }}'
+    helm_release_channel: '{{ helm_vars.release.repository.url }}/{{ helm_vars.release.repository.channel }}'
   run_once: true
 
 - name: Set release key fact
   ansible.builtin.set_fact:
-    helm_release_key: '{{ helm_vars.release.helm.repository.url }}/{{ helm_vars.release.helm.repository.key }}'
+    helm_release_key: '{{ helm_vars.release.repository.url }}/{{ helm_vars.release.repository.key }}'
   run_once: true

--- a/roles/helm/tasks/main.yaml
+++ b/roles/helm/tasks/main.yaml
@@ -8,6 +8,10 @@
   ansible.builtin.import_tasks:
     file: validation.yaml
 
+- name: Role Maintenaance
+  ansible.builtin.import_tasks:
+    file: maintenance.yaml
+
 - name: Role Provisioning
   when: ansible_host in k3s_server_hosts
   block:
@@ -22,7 +26,7 @@
 
     - name: Get file status
       ansible.builtin.stat:
-        path: /usr/share/keyrings/{{ helm_vars.release.helm.key }}
+        path: /usr/share/keyrings/{{ helm_vars.release.key }}
       changed_when: not gpg_key.stat.exists
       register: gpg_key
 
@@ -32,7 +36,7 @@
         - name: Download key
           ansible.builtin.get_url:
             url: '{{ helm_release_key }}'
-            dest: /tmp/{{ helm_vars.release.helm.repository.key }}
+            dest: /tmp/{{ helm_vars.release.repository.key }}
             owner: root
             group: root
             mode: '0644'
@@ -43,13 +47,13 @@
 
         - name: Dearmor key
           ansible.builtin.command:
-            cmd: gpg --dearmor -o /usr/share/keyrings/{{ helm_vars.release.helm.key }} /tmp/{{ helm_vars.release.helm.repository.key }}
+            cmd: gpg --dearmor -o /usr/share/keyrings/{{ helm_vars.release.key }} /tmp/{{ helm_vars.release.repository.key }}
           changed_when: dearmor_key.rc == 0
           register: dearmor_key
 
         - name: Delete key
           ansible.builtin.file:
-            path: /tmp/{{ helm_vars.release.helm.repository.key }}
+            path: /tmp/{{ helm_vars.release.repository.key }}
             state: absent
 
         - name: Get architecture
@@ -62,10 +66,10 @@
           ansible.builtin.deb822_repository:
             architectures: '{{ architecture.stdout }}'
             components: main
-            name: helm-{{ helm_vars.release.helm.repository.channel }}
-            signed_by: /usr/share/keyrings/{{ helm_vars.release.helm.key }}
+            name: helm-{{ helm_vars.release.repository.channel }}
+            signed_by: /usr/share/keyrings/{{ helm_vars.release.key }}
             suites: all
-            uris: '{{ helm_release_channel }}/{{ helm_vars.release.helm.distro }}/'
+            uris: '{{ helm_release_channel }}/{{ helm_vars.release.distro }}/'
             enabled: true
             trusted: true
 
@@ -75,42 +79,46 @@
             autoremove: true
             update_cache: true
 
-    - name: Install Helm Plugin
-      when: helm_vars.release.plugin.enabled
+    - name: Install Helm Plugins
       block:
-        - name: Install plugin package
+        - name: Install plugin packages
           ansible.builtin.apt:
-            name: python3-jsonpatch
+            name: '{{ item }}'
             autoremove: true
             update_cache: true
+          loop: '{{ helm_plugin_packages | default([]) }}'
 
-        - name: Install plugin
+        - name: Install plugins
           kubernetes.core.helm_plugin:
-            plugin_path: '{{ helm_plugin_release_url }}'
-            plugin_version: '{{ helm_vars.release.plugin.version }}'
+            plugin_path: '{{ item.repository.url }}'
+            plugin_version: '{{ item.version }}'
+          loop: '{{ helm_vars.plugins }}'
           register: result
           delay: 1
           retries: 3
           until: result is not failed
+          when: item.enabled
 
-    - name: Remove Helm Plugin
-      when: not helm_vars.release.plugin.enabled
+    - name: Remove Helm Plugins
       block:
         - name: Get packages information
           ansible.builtin.package_facts:
 
-        - name: Remove plugin
+        - name: Remove plugins
           kubernetes.core.helm_plugin:
-            plugin_name: '{{ helm_vars.release.plugin.name }}'
+            plugin_name: '{{ item.name }}'
             state: absent
+          loop: '{{ helm_vars.plugins }}'
           when:
+            - not item.enabled
             - "'helm' in ansible_facts.packages"
             - "'python3-kubernetes' in ansible_facts.packages"
 
-        - name: Remove plugin package
+        - name: Remove plugin packages
           ansible.builtin.apt:
-            name: python3-jsonpatch
+            name: '{{ item }}'
             state: absent
             autoremove: true
             clean: true
             purge: true
+          loop: '{{ helm_plugin_packages_disabled | default([]) }}'

--- a/roles/helm/tasks/maintenance.yaml
+++ b/roles/helm/tasks/maintenance.yaml
@@ -1,0 +1,14 @@
+---
+- name: Get user info
+  ansible.builtin.user:
+    name: root
+  register: user_info
+
+- name: Remove generic files
+  ansible.builtin.file:
+    name: '{{ user_info.home }}/.{{ item }}'
+    state: absent
+  loop:
+    - cache
+    - config
+    - local

--- a/roles/helm/tasks/reset.yaml
+++ b/roles/helm/tasks/reset.yaml
@@ -7,29 +7,28 @@
 - name: Role Reset
   when: ansible_host in k3s_server_hosts
   block:
-    - name: Remove Helm Plugin
-      when: helm_vars.release.plugin.enabled
-      block:
-        - name: Remove plugin
-          kubernetes.core.helm_plugin:
-            plugin_name: '{{ helm_vars.release.plugin.name }}'
-            state: absent
-          when:
-            - "'helm' in ansible_facts.packages"
-            - "'python3-kubernetes' in ansible_facts.packages"
+    - name: Remove plugin
+      kubernetes.core.helm_plugin:
+        plugin_name: '{{ item.name }}'
+        state: absent
+      loop: '{{ helm_vars.plugins }}'
+      when:
+        - "'helm' in ansible_facts.packages"
+        - "'python3-kubernetes' in ansible_facts.packages"
 
-        - name: Remove plugin package
+    - name: Remove Packages
+      when: prompt_remove_packages in ['y', 'Y']
+      block:
+        - name: Remove plugin packages
           ansible.builtin.apt:
-            name: python3-jsonpatch
+            name: '{{ item.packages }}'
             state: absent
             autoremove: true
             clean: true
             purge: true
-          when: prompt_remove_packages in ['y', 'Y']
+          loop: '{{ helm_vars.plugins }}'
+          when: item.packages is defined
 
-    - name: Remove Helm Packages
-      when: prompt_remove_packages in ['y', 'Y']
-      block:
         - name: Remove packages
           ansible.builtin.apt:
             name: '{{ item }}'
@@ -47,5 +46,9 @@
             name: '{{ item }}'
             state: absent
           loop:
-            - /etc/apt/sources.list.d/helm-{{ helm_vars.release.helm.repository.channel }}.sources
-            - /usr/share/keyrings/{{ helm_vars.release.helm.key }}
+            - /etc/apt/sources.list.d/helm-{{ helm_vars.release.repository.channel }}.sources
+            - /usr/share/keyrings/{{ helm_vars.release.key }}
+
+- name: Role Maintenaance
+  ansible.builtin.import_tasks:
+    file: maintenance.yaml

--- a/roles/helm/tasks/validation.yaml
+++ b/roles/helm/tasks/validation.yaml
@@ -3,15 +3,17 @@
   ansible.builtin.import_tasks:
     file: facts.yaml
 
-- name: Validate plugin release url
+- name: Validate plugins release url
   ansible.builtin.uri:
-    url: '{{ helm_plugin_release_url }}/releases/tag/{{ helm_vars.release.plugin.version }}'
+    url: '{{ item.repository.url }}/releases/tag/{{ item.version }}'
     timeout: 5
+  loop: '{{ helm_vars.plugins }}'
   run_once: true
   register: result
   delay: 1
   retries: 3
   until: result is not failed
+  when: item.enabled
 
 - name: Validate release key url
   ansible.builtin.uri:

--- a/roles/kured/tasks/facts.yaml
+++ b/roles/kured/tasks/facts.yaml
@@ -11,10 +11,10 @@
 
 - name: Set project url fact
   ansible.builtin.set_fact:
-    kured_project_url: https://github.com/{{ kured_project_release }}/releases
+    kured_project_url: https://github.com/{{ kured_project_release }}/releases/tag
   run_once: true
 
 - name: Set project tag url fact
   ansible.builtin.set_fact:
-    kured_project_url_tag: '{{ kured_project_url }}/tag/{{ kured_vars.kubernetes.helm.chart.name }}-{{ kured_vars.kubernetes.helm.chart.version[1:] }}'
+    kured_project_url_tag: '{{ kured_project_url }}/{{ kured_vars.kubernetes.helm.chart.name }}-{{ kured_vars.kubernetes.helm.chart.version[1:] }}'
   run_once: true

--- a/roles/kured/tasks/main.yaml
+++ b/roles/kured/tasks/main.yaml
@@ -33,6 +33,7 @@
           kubernetes.core.helm:
             chart_ref: '{{ kured_project_chart }}'
             chart_version: '{{ kured_vars.kubernetes.helm.chart.version }}'
+            create_namespace: true
             kubeconfig: '{{ k3s_vars.directory.config }}/k3s.yaml'
             name: '{{ kured_vars.kubernetes.helm.chart.name }}'
             namespace: '{{ kured_vars.kubernetes.namespace }}'

--- a/roles/longhorn/tasks/facts.yaml
+++ b/roles/longhorn/tasks/facts.yaml
@@ -6,10 +6,10 @@
 
 - name: Set project url fact
   ansible.builtin.set_fact:
-    longhorn_project_url: https://github.com/{{ longhorn_project_chart }}/releases
+    longhorn_project_url: https://github.com/{{ longhorn_project_chart }}/releases/tag
   run_once: true
 
 - name: Set project tag url fact
   ansible.builtin.set_fact:
-    longhorn_project_url_tag: '{{ longhorn_project_url }}/tag/{{ longhorn_vars.kubernetes.helm.chart.version }}'
+    longhorn_project_url_tag: '{{ longhorn_project_url }}/{{ longhorn_vars.kubernetes.helm.chart.version }}'
   run_once: true

--- a/roles/longhorn/tasks/main.yaml
+++ b/roles/longhorn/tasks/main.yaml
@@ -33,6 +33,7 @@
           kubernetes.core.helm:
             chart_ref: '{{ longhorn_project_chart }}'
             chart_version: '{{ longhorn_vars.kubernetes.helm.chart.version }}'
+            create_namespace: true
             kubeconfig: '{{ k3s_vars.directory.config }}/k3s.yaml'
             name: '{{ longhorn_vars.kubernetes.helm.chart.name }}'
             namespace: '{{ longhorn_vars.kubernetes.namespace }}'

--- a/roles/prometheus/tasks/facts.yaml
+++ b/roles/prometheus/tasks/facts.yaml
@@ -16,12 +16,12 @@
 
 - name: Set project url fact
   ansible.builtin.set_fact:
-    prometheus_project_url: https://github.com/{{ prometheus_project_release }}/releases
+    prometheus_project_url: https://github.com/{{ prometheus_project_release }}/releases/tag
   run_once: true
 
 - name: Set project tag url fact
   ansible.builtin.set_fact:
-    prometheus_project_url_tag: '{{ prometheus_project_url }}/tag/{{ prometheus_project_tag }}'
+    prometheus_project_url_tag: '{{ prometheus_project_url }}/{{ prometheus_project_tag }}'
   run_once: true
 
 - name: Set variables fact

--- a/roles/prometheus/tasks/main.yaml
+++ b/roles/prometheus/tasks/main.yaml
@@ -39,6 +39,7 @@
           kubernetes.core.helm:
             chart_ref: '{{ prometheus_project_chart }}'
             chart_version: '{{ prometheus_vars.kubernetes.helm.chart.version }}'
+            create_namespace: true
             kubeconfig: '{{ k3s_vars.directory.config }}/k3s.yaml'
             name: '{{ prometheus_vars.kubernetes.helm.chart.prefix }}'
             namespace: '{{ prometheus_vars.kubernetes.namespace }}'


### PR DESCRIPTION
## WHY

Restructure helm plugins code, a proper fix is also included for #77. The new implementation allows end-user to insert additional helm plugins to be installed, as well to uninstall them with a role upgrade. See `helm-git` example with optional `packages` not present:

```yaml
helm_vars:
  plugins:
    - name: helm-diff
      enabled: true
      packages:
        - python3-jsonpatch
      repository:
        url: https://github.com/databus23/helm-diff
      version: v3.9.6
    - name: helm-git
      enabled: false
      repository:
        url: https://github.com/aslafy-z/helm-git
      version: v0.16.0
```

Setting the `enable` setting to `false` will prohibit the plugin installation. Also, disabling a plugin into settings and running the `helm` upgrade task, will remove the related plugin from the cluster.

## WHAT

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not working as expected)
- [x] This change requires a documentation update

## HOW

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
