### PR TITLE
fix: renovate allowed author

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -350,6 +350,9 @@
     ":semanticCommitTypeAll(chore)",
     "config:recommended"
   ],
+  "gitIgnoredAuthors": [
+    "github-actions[bot]@users.noreply.github.com"
+  ],
   "labels": [
     "dependency"
   ],


### PR DESCRIPTION
## WHY

Allow Renovate to recognize GitHub Actions Bot as commit author.

## WHAT

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not working as expected)
- [ ] This change requires a documentation update

## HOW

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
