### PR TITLE
fix: external-dns release

### DIFF
--- a/roles/external-dns/defaults/main.yaml
+++ b/roles/external-dns/defaults/main.yaml
@@ -13,7 +13,7 @@ externaldns_vars:
     helm:
       chart:
         name: external-dns
-        version: v1.16.0
+        version: v1.15.2
       repository:
         name: external-dns
         org: kubernetes-sigs


### PR DESCRIPTION
## WHY

A `helm diff upgrade` from version `1.15.2` to version `1.16.0` produces the following error:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
external-dns:
- serviceMonitor.scrapeTimeout: Invalid type. Expected: null, given: string
- serviceMonitor.interval: Invalid type. Expected: null, given: string
- serviceMonitor.namespace: Invalid type. Expected: null, given: string
```

Related to https://github.com/kubernetes-sigs/external-dns/issues/5206.

## WHAT

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not working as expected)
- [ ] This change requires a documentation update

## HOW

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
