### PR TITLE
fix: set helm-docs default file

### DIFF
--- a/.github/scripts/documentation.js
+++ b/.github/scripts/documentation.js
@@ -101,10 +101,10 @@ async function updateDocumentation({
       .filter((dir, index, self) => self.indexOf(dir) === index); // Unique directories
     if (!dirs.length) {
       core.info('No specific directories found, running helm-docs on all directories');
-      await exec.exec('helm-docs', ['-l', config('workflow').docs.logLevel]);
+      await exec.exec('helm-docs', ['-f', './defaults/main.yaml', '-l', config('workflow').docs.logLevel]);
     } else {
       const dirsList = dirs.join(',');
-      await exec.exec('helm-docs', ['-g', dirsList, '-l', config('workflow').docs.logLevel]);
+      await exec.exec('helm-docs', ['-f', './defaults/main.yaml', '-g', dirsList, '-l', config('workflow').docs.logLevel]);
     }
     await runGit(['add', '.']);
     const files = (await runGit(['diff', '--staged', '--name-only']))


### PR DESCRIPTION
## Objective

Set  helm-docs default file, in order to correctly build documentation.

## Scope

- [x] Bug (resolves an issue)
- [ ] Enhancement (improves existing functionality)
- [ ] Feature (adds new functionality)
- [ ] Documentation (adds or improves documentation)

### Impact

- [x] Non-breaking (backwards compatible)
- [ ] Breaking (backwards incompatible, impacts end-user)

## Checklist

- [x] My code follows the contributing guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
