### PR TITLE
fix: scrape endpoint

### DIFF
--- a/roles/coredns/templates/config_servers.j2
+++ b/roles/coredns/templates/config_servers.j2
@@ -5,11 +5,13 @@
 
 - zones:
     - zone: .
+      use_tcp: true
   port: 53
   plugins:
     - name: errors
     - name: health
-      configBlock: lameduck 5s
+      configBlock: |-
+        lameduck 10s
     - name: ready
     - name: kubernetes
       parameters: {{ k3s_vars.cluster.domain }} in-addr.arpa ip6.arpa

--- a/roles/victoria-metrics/templates/values.j2
+++ b/roles/victoria-metrics/templates/values.j2
@@ -86,9 +86,9 @@ coreDns:
 {% endif %}
   vmScrape:
     spec:
-      endpoints:
-        - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-          port: metrics
+      namespaceSelector:
+        matchNames:
+          - {{ coredns_vars.kubernetes.namespace }}
 defaultDashboards:
   dashboards:
     victoriametrics-operator:


### PR DESCRIPTION
## Objective

Applied fixes:

- set correct `vmagent` scrape endpoint
- set CoreDNS TCP as primary protocol

## Scope

- [x] Bug (resolves an issue)
- [ ] Enhancement (improves existing functionality)
- [ ] Feature (adds new functionality)
- [ ] Documentation (adds or improves documentation)

### Impact

- [x] Non-breaking (backwards compatible)
- [ ] Breaking (backwards incompatible, impacts end-user)

## Checklist

- [x] My code follows the contributing guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
